### PR TITLE
chore(ci): create docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:6-slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 6.9
+  services:
+    - docker
 
 dependencies:
   cache_directories:
@@ -9,15 +11,25 @@ dependencies:
     - npm prune && npm install
 
 test:
+  pre:
+    - npm run build
   override:
 #   - npm run lint
     - npm test
     - npm run test-api
+  post:
+    - docker build -t interledgerjs/ilp-kit:latest .
+    - docker tag interledgerjs/ilp-kit:latest interledgerjs/ilp-kit:"$(git describe --tags)"
+
 
 deployment:
   production:
     branch: master
     commands:
+      # Push Docker image tagged latest and tagged with commit descriptor
+      - sed "s/<AUTH>/${DOCKER_TOKEN}/" < "dockercfg-template" > ~/.dockercfg
+      - docker push interledgerjs/ilp-kit:latest
+      - docker push interledgerjs/ilp-kit:"$(git describe)"
       # Publish spec
       - git config --global user.email "info@circleci.com"
       - git config --global user.name "CircleCI"

--- a/dockercfg-template
+++ b/dockercfg-template
@@ -1,0 +1,1 @@
+{"https://index.docker.io/v1/":{"auth":"<AUTH>","email":""}}


### PR DESCRIPTION
Pretty straightforward: Creates a Docker image of ilp-kit and uploads it to Docker Hub.

First build on master might fail since there aren't any tags yet, but that's easily fixed by tagging and rebuilding.