### PR TITLE
feat: Makes path to env.list configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ ILP wallet with hosted ledger and connector instances
 
 ## Environment variables
 
+Note: Most of the variables can either be set as environment variable or in a config file. The default config file is `env.list`. Environment variables take precedence over variables set in the config file.
+
 ##### Required
 
 Name | Example | Description |
@@ -53,6 +55,7 @@ Name | Example | Description |
 
 Name | Example | Description |
 ---- | ------- | ----------- |
+`API_CONFIG_FILE` | custom-env.list | Specifies the path from which to load the config file. **Needs to be defined as environment variable**.
 `API_PUBLIC_HTTPS` |  | Whether or not the publicly visible instance of ILP kit is using HTTPS.
 `API_PRIVATE_HOSTNAME` | `localhost` | Private API hostname.
 `API_PUBLIC_PORT` |  | Api public port.

--- a/bin/normalizeEnv.js
+++ b/bin/normalizeEnv.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const crypto = require('crypto')
-const sodium = require('sodium-prebuilt')
 const _ = require('lodash')
 
 const envVars = {}
@@ -13,10 +12,22 @@ const getVar = (name, def = false) => {
   return process.env[name] || envVars[name] || def
 }
 
+function getConfigFilePath() {
+  let file = ''
+  // was an alternative path to the config file specified?
+  if (getVar('API_CONFIG_FILE')) {
+    // use alternative file path
+    file = getVar('API_CONFIG_FILE')
+  } else {
+    // use default file path
+    file = process.env.NODE_ENV === 'test' ? 'test.env.list' : 'env.list'
+  }
+  return file
+}
+
 // get env vars from the env file
 try {
-  const file = process.env.NODE_ENV === 'test' ? 'test.env.list' : 'env.list'
-
+  const file = getConfigFilePath()
   const envFile = fs.readFileSync(file)
   const fileLines = envFile.toString().split('\n')
 


### PR DESCRIPTION
Currently the file name of the config file is assumed to be either env.list or test.env.list. This commit allows to use a custom path to the config file by setting the env. var. API_CONFIG_FILE.