### PR TITLE
fix: check error status code as backup to detect NotFound Error

### DIFF
--- a/api/src/lib/ledger.js
+++ b/api/src/lib/ledger.js
@@ -67,7 +67,11 @@ module.exports = class Ledger extends EventEmitter {
       if (e.response && e.response.body &&
          (e.response.body.id === 'NotFoundError' ||
           e.response.body.id === 'UnauthorizedError')) {
-        throw new NotFoundError(e.response.body.message)
+        throw new NotFoundError(e.response.body.message) // TODO: Use ILPException?
+      } else if (e.response && e.response.status &&
+         (e.response.status === 401 ||
+          e.response.status === 404)) {
+        throw new NotFoundError(JSON.stringify(e.response.body))
       } else {
         throw e
       }


### PR DESCRIPTION
Use  e.response.status as "backup" to detect not-found exception if e.response.body.message doesn't match.

