### PR TITLE
docs(dev): improve dev setup instructions

### DIFF
--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -2,34 +2,40 @@
 
 Clone the repo
 ```bash
-git clone git@github.com:interledgerjs/ilp-kit.git
+git clone -b v4 git@github.com:interledgerjs/ilp-kit.git
 ```
 
 Configure the environment
 ```bash
 cd ilp-kit
-npm install
+npm run install-all
+```
+
+> **Note:** `npm install-all` will run the following commands:
+>
+> ```bash
+> npm install
+> cd ledger; npm install; cd ..
+> cd api; npm install; cd ..
+> cd client; npm install; cd ..
+> cd webserver; npm install; cd ..
+> ```
+
+Configure your installation:
+
+```bash
 npm run configure
+cp client/public/config.example.js client/public/config.js
 ```
 
-Setup the ledger
-```bash
-cd ledger
-npm install
-```
+> **Note:** Use `wallet1.com` as your hostname when asked by `npm run configure`.
 
-Setup the api
-```bash
-cd ../api
-npm install
-```
-
-Setup the client
-```bash
-cd ../client
-cp public/config.example.js public/config.js
-npm install
-```
+> **Hint:** If you don't have Postgres running already, but you have Docker, you can start a development database with the following commands:
+>
+> ```bash
+> docker pull postgres
+> docker run -it --rm -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=ilpkit --name ilpkitpostgres -p 5432:5432 postgres
+> ```
 
 Edit your hosts file (`/private/etc/hosts` on OSX). Add this line.
 
@@ -37,7 +43,9 @@ Edit your hosts file (`/private/etc/hosts` on OSX). Add this line.
 127.0.0.1   wallet1.com
 ```
 
-### Port forwarding (simple)
+## Port forwarding
+
+### Option A: Port forwarding (simple)
 
 > NOTE: Current webfinger implementation will not work if the public ports 443 and 80 don't point to the development server.
 
@@ -46,7 +54,13 @@ cd webserver
 npm run start-dev
 ```
 
-### Port forwarding (Virtual hosts)
+> **Hint:** In order to run the proxy, you may need *sudo*:
+>
+> ```bash
+> sudo npm run start-dev
+> ```
+
+### Option B: Port forwarding (Virtual hosts)
 
 If you would like to set up two ILP Kits on the same host, it's a good idea to use nginx or apache for the virtual host handling.
 
@@ -76,6 +90,8 @@ npm run start
 cd client
 npm run start
 ```
+
+Congratulations, your development instance is up and running! Go to https://wallet1.com and bypass the certificate warning in order to access your development ILP Kit.
 
 ## Run the integration tests with Docker
 We have a docker image which is useful for running the integration tests. The following command (when run from the

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -81,17 +81,17 @@ There are 3 processes that need to be run. Ledger, Api and the Client.
 
 ```bash
 cd ledger
-npm run start
+npm start
 ```
 
 ```bash
 cd api
-npm run start
+npm start
 ```
 
 ```bash
 cd client
-npm run start
+npm start
 ```
 
 Congratulations, your development instance is up and running! Go to https://wallet1.com and bypass the certificate warning in order to access your development ILP Kit.

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -5,21 +5,24 @@ Clone the repo
 git clone -b v4 git@github.com:interledgerjs/ilp-kit.git
 ```
 
-Configure the environment
+Install dependencies
 ```bash
 cd ilp-kit
-npm run install-all
+npm install
 ```
 
-> **Note:** `npm install-all` will run the following commands:
+> **Note:** `npm install` will automatically install the dependencies of each of
+> the subcomponents by running the following commands:
 >
 > ```bash
-> npm install
 > cd ledger; npm install; cd ..
 > cd api; npm install; cd ..
 > cd client; npm install; cd ..
 > cd webserver; npm install; cd ..
 > ```
+>
+> If you don't want to run these commands for some reason, you can use
+> `npm install --ignore-scripts` instead.
 
 Configure your installation:
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "configure": "./node_modules/ilp-kit-cli/bin/configure.js",
-    "install-all": "npm install ; cd ledger; npm install; cd .. ; cd api; npm install; cd .. ; cd client; npm install; cd .. ; cd webserver; npm install"
+    "postinstall": "cd ledger; npm install; cd .. ; cd api; npm install; cd .. ; cd client; npm install; cd .. ; cd webserver; npm install"
   },
   "dependencies": {
     "five-bells-shared": "^25.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "finance"
   ],
   "scripts": {
-    "configure": "./node_modules/ilp-kit-cli/bin/configure.js"
+    "configure": "./node_modules/ilp-kit-cli/bin/configure.js",
+    "install-all": "npm install ; cd ledger; npm install; cd .. ; cd api; npm install; cd .. ; cd client; npm install; cd .. ; cd webserver; npm install"
   },
   "dependencies": {
     "five-bells-shared": "^25.1.1",


### PR DESCRIPTION
Several improvements to the development setup instructions:

* Change clone command to use `v4` branch.
* Create an `npm run install-all` shortcut command instead of manually cd-ing and installing.
* Add a hint to use the wallet1.com hostname when running `npm run configure`.
* Add note that you may have to use sudo to run the proxy.
* Add npm install for the proxy webserver.
* Make it more clear that you only need to follow one of the two local forwarding sections.
* Add a "next step" for what to do after installation.